### PR TITLE
fix: corrected ParseServiceData data length check

### DIFF
--- a/src/controller/python/chip/ChipBleUtility.py
+++ b/src/controller/python/chip/ChipBleUtility.py
@@ -42,6 +42,9 @@ BLE_ERROR_REMOTE_DEVICE_DISCONNECTED = 12
 
 FAKE_CONN_OBJ_VALUE = 12121212
 
+# Number of bytes in service data payload
+SERVICE_DATA_LEN = 8
+
 
 def VoidPtrToUUIDString(ptr, len):
     try:
@@ -365,7 +368,7 @@ class BleDeviceIdentificationInfo:
 
 
 def ParseServiceData(data):
-    if len(data) != 7:
+    if len(data) != SERVICE_DATA_LEN:
         return None
     return BleDeviceIdentificationInfo(
         int(data[0]),


### PR DESCRIPTION
#### Problem
The ParseServiceData function was broken. The length check was utilizing a length of 7 which caused the function to always return None.

#### Change overview
The correct length of the data parameter is 8. I have made this a constant at the top of the file to also remove the use of a magic number.

#### Testing
Manually tested against both Darwin and Linux Python controller applications.
